### PR TITLE
Bugfix for issue #1 "Using imagemagick instead of graphicsmagick"

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -17,6 +17,44 @@ module.exports = (grunt) ->
         options:
           skipExisting: false
           stopOnError: false
+          imageMagick: false
+          yourcustomopt:
+            'test/gruntjs.png': '"JavaScript Task Runner"'
+            'test/nodejs.png': '"JavaScript Runtime"'
+        files: [
+            cwd: 'test'
+            dest: 'test/out'
+            expand: true
+            filter: 'isFile'
+            src: ['**/*', '!**/out/*', '!{film,sample}.png']
+            options:
+              skipExisting: false
+              stopOnError: true
+            tasks: [
+                resize: [200]
+                command: ['composite']
+                in: ['test/sample.png']
+              ,
+                gravity: ['Center']
+                extent: [400, 360]
+              ,
+                command: ['composite']
+                in: ['test/film.png']
+              ,
+                gravity: ['North']
+                font: ['arial', 30]
+                draw: [
+                  'skewX', -13
+                  'fill', '#999', 'text', 2, 67, (f) -> f.options.yourcustomopt[f.src[0]]
+                  'fill', '#000', 'text', 0, 65, (f) -> f.options.yourcustomopt[f.src[0]]
+                ]
+            ]
+        ]
+      testImageMagick:
+        options:
+          skipExisting: false
+          stopOnError: false
+          imageMagick: true
           yourcustomopt:
             'test/gruntjs.png': '"JavaScript Task Runner"'
             'test/nodejs.png': '"JavaScript Runtime"'
@@ -53,4 +91,4 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-coffee'
   grunt.loadTasks 'tasks'
 
-  grunt.registerTask 'default', ['gm']
+  grunt.registerTask 'default', ['gm:test']

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ grunt.initConfig({
         skipExisting: false,
         // default: false
         stopOnError: false,
+        // default: false, set true to use ImageMagick instead of GraphicsMagick
+        imageMagick: false,
         // task options will also be passed to arg callback
         yourcustomopt: {
           'test/gruntjs.png': '"JavaScript Task Runner"',
@@ -134,4 +136,3 @@ Original|After&nbsp;Task&nbsp;#1|After&nbsp;Task&nbsp;#2|After&nbsp;Task&nbsp;#3
 [2]: http://www.graphicsmagick.org
 [3]: http://www.imagemagick.org
 [4]: https://github.com/aheckmann/gm#basic-usage
-

--- a/tasks/gm.js
+++ b/tasks/gm.js
@@ -41,8 +41,13 @@ module.exports = function(grunt) {
         count++;
         opts = extend({}, _this.data.options, file.options, {
           skipExisting: grunt.option('skipExisting'),
-          stopOnError: grunt.option('stopOnError')
+          stopOnError: grunt.option('stopOnError'),
+          imageMagick: grunt.option('imageMagick')
         });
+        if(opts.imageMagick){
+            // Overwrite gm to use ImageMagick instead of GraphicsMagick
+            gm = require('gm').subClass({imageMagick: true});
+        }
         if (opts.skipExisting && fs.existsSync(file.dest) && fs.statSync(file.dest).size) {
           grunt.verbose.writeln("Processing " + file.src + "...skipped, " + count + "/" + total);
           skippedItems.push(file.dest);


### PR DESCRIPTION
This PR include a bugfix for the issue #1 "Using imagemagick instead of graphicsmagick".

It adds  new option  `{imageMagick:true}` comparable to aheckmann gm. 
It does not adopt the implementation using `subClass({imageMagick: true})`, because that would required rewriting this grunt task. 